### PR TITLE
Fix README and DB_URI inconsistencies.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DB_URI=mongodb+srv://=<username>:<password>@<database>-g3uup.mongodb.net/<collection>?retryWrites=true&w=majority

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@
 Lol it's like, a URL shortener, that's it.
 
 ## Usage
-1. Clone either using Git or by [downloading](https://github.com/vanajmoorthy/mcow.ml/archive/master.zip)
+1. Grab source by either using Git to clone or by [downloading](https://github.com/vanajmoorthy/mcow.ml/archive/master.zip)
 2. Run either `yarn` or `npm i` to install dependencies.
-3. Rename `.env.example` to `.env` and replace the marked fields with the proper credentials.
+3. Rename [`.env.example`](https://github.com/vanajmoorthy/mcow.ml/blob/master/.env.example) to `.env` and replace the marked fields with the proper credentials.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,7 @@
 
 Lol it's like, a URL shortener, that's it.
 
-Clone using git, run npm install add a .env with your MongoDB connection string under a variable called DB_URI lol that's all it's pretty simple
+## Usage
+1. Clone either using Git or by [downloading](https://github.com/vanajmoorthy/mcow.ml/archive/master.zip)
+2. Run either `yarn` or `npm i` to install dependencies.
+3. Rename `.env.example` to `.env` and replace the marked fields with the proper credentials.

--- a/server.js
+++ b/server.js
@@ -6,11 +6,11 @@ const crypto = require("crypto");
 const favicon = require("serve-favicon");
 require("dotenv").config();
 
-const pass = process.env.PASS;
+const DB_URI = process.env.DB_URI;
 
 mongoose
 	.connect(
-		`mongodb+srv://admin:${pass}@short.xd39u.mongodb.net/short?retryWrites=true&w=majority`,
+		DB_URI,
 		{
 			useNewUrlParser: true,
 			useUnifiedTopology: true,


### PR DESCRIPTION
**Problem**: The previous README stated to make a `.env` variable named `DB_URI` however, `server.js` asked for a variable named `PASS`.
**Fix**: Changing `server.js` to grab a environment variable named `DB_URI` which is present in the `.env.example` and then using that variable as the MongoDB URI.

**Chore**: README had subpar usage information.
**Fix**: Added a ordered list to depict the steps of usage.