### PR TITLE
Change regex being used to check the short type

### DIFF
--- a/server.js
+++ b/server.js
@@ -76,7 +76,7 @@ app.post("/shorten", createAccountLimiter, async (req, res) => {
 	const type =
 		req.body.short === "" ||
 		req.body.short === null ||
-		!req.body.short.match(/[A-Z][a-z][1-9]/) ||
+		!req.body.short.match(/[A-Za-z0-9]/) ||
 		isEmpty(req.body.short)
 			? "generated"
 			: "manual";


### PR DESCRIPTION
I noticed an issue where manual short URLs were being stored as generated. This allowed for different URLs to have the same short since the code wasn't finding any manual entries. I saw the issue was due to the regex being used to check for the type. It was returning true even when text was entered. I've modified the regex so that it properly detects a manual entry. 